### PR TITLE
Instrument page selector fix

### DIFF
--- a/src/hooks/ticks-pages.ts
+++ b/src/hooks/ticks-pages.ts
@@ -3,11 +3,15 @@ import { CustomEventNames } from '@utils/event';
 import { DEFAULT_MAIN_PAGES, TICKS_BY_PAGE } from '@utils/default_values';
 import { useEventListener } from './event-listener';
 
+let acutalMainPages = DEFAULT_MAIN_PAGES;
+
 export const useTicksPagesListener = () => {
   const mainNumPages = useEventListener(
     CustomEventNames.mainPages,
-    DEFAULT_MAIN_PAGES,
+    acutalMainPages,
   );
+
+  acutalMainPages = mainNumPages;
 
   const maxTicksValue = useMemo(
     () => TICKS_BY_PAGE * mainNumPages,


### PR DESCRIPTION
When adding a new instrument, the default ticks is set to 64 even if the max ticks is set to 3 or less pages. This was fixed here.